### PR TITLE
Resolve issues #7 and #8

### DIFF
--- a/src/backpack_tf/__init__.py
+++ b/src/backpack_tf/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa: F401, F403
 __title__ = "backpack-tf"
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "offish"
 __license__ = "MIT"
 

--- a/src/backpack_tf/classes.py
+++ b/src/backpack_tf/classes.py
@@ -50,6 +50,7 @@ class Listing:
     status: str
     source: str
     item: dict[str, Any]
+    deal: dict[str, Any] = field(default_factory=dict)
     user: dict = field(default_factory=dict)  # Made optional for API compatibility
     userAgent: dict = field(default_factory=dict)
     tradeOffersPreferred: bool = None

--- a/src/backpack_tf/utils.py
+++ b/src/backpack_tf/utils.py
@@ -32,7 +32,6 @@ def construct_listing(
         raise InvalidIntent(f"{intent} must be buy or sell")
 
     listing = {
-        "item": construct_listing_item(sku),
         "buyout": True,
         "offers": True,
         "promoted": False,
@@ -42,6 +41,8 @@ def construct_listing(
 
     if intent == "sell":
         listing["id"] = asset_id
+    elif intent == "buy":
+        listing["item"] = construct_listing_item(sku)
 
     return listing
 

--- a/tests/test_backpack_tf.py
+++ b/tests/test_backpack_tf.py
@@ -41,12 +41,6 @@ def test_construct_listing() -> None:
         "buyout": True,
         "offers": True,
         "promoted": False,
-        "item": {
-            "baseName": "Ellis' Cap",
-            "craftable": True,
-            "quality": {"id": 6},
-            "tradable": True,
-        },
         "currencies": {"keys": 1, "metal": 1.55},
         "details": "my description",
         "id": 13201231975,

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,7 +1,46 @@
-from src.backpack_tf import Currencies
+from src.backpack_tf import Currencies, Listing
 
 
 def test_currencies() -> None:
     assert Currencies().__dict__ == {"keys": 0, "metal": 0.0}
     assert Currencies(1, 1.5).__dict__ == {"keys": 1, "metal": 1.5}
     assert Currencies(**{"metal": 10.55}).__dict__ == {"keys": 0, "metal": 10.55}
+
+
+def test_listing_allows_optional_deal() -> None:
+    listing_without_deal = Listing(
+        id="id",
+        steamid="steamid",
+        appid=440,
+        currencies={"metal": 1.0},
+        value={"raw": 1.0},
+        details="details",
+        listedAt=1,
+        bumpedAt=1,
+        intent="buy",
+        count=1,
+        status="active",
+        source="user",
+        item={"defindex": 5021},
+    )
+
+    assert listing_without_deal.deal == {}
+
+    listing_with_deal = Listing(
+        id="id",
+        steamid="steamid",
+        appid=440,
+        currencies={"metal": 1.0},
+        value={"raw": 1.0},
+        details="details",
+        listedAt=1,
+        bumpedAt=1,
+        intent="buy",
+        count=1,
+        status="active",
+        source="user",
+        item={"defindex": 5021},
+        deal={"percent": 0.11, "value": 33.88},
+    )
+
+    assert listing_with_deal.deal == {"percent": 0.11, "value": 33.88}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,12 +29,6 @@ def test_construct_listing() -> None:
         "buyout": True,
         "offers": True,
         "promoted": False,
-        "item": {
-            "baseName": "Ellis' Cap",
-            "craftable": True,
-            "quality": {"id": 6},
-            "tradable": True,
-        },
         "currencies": {"keys": 1, "metal": 1.55},
         "details": "my description",
         "id": 13201231975,


### PR DESCRIPTION
1. #7 : Listing class optionally accepts `deal` if exists
2. #8 : input payload to create listings send `item` only when buy, `id` only when sell